### PR TITLE
fix(staticWado):Make the thumbnail not cause failures on video/other

### DIFF
--- a/packages/static-cs-lite/lib/adapters/canvasImageToBuffer.js
+++ b/packages/static-cs-lite/lib/adapters/canvasImageToBuffer.js
@@ -11,10 +11,9 @@ function canvasImageToBuffer(canvas, imageType = "image/jpeg") {
     const dataUrl = canvas.toDataURL(imageType, 1);
     const base64Data = dataUrl.replace(/^data:image\/(jpeg|png);base64,/, "");
     result = Buffer.from(base64Data, "base64");
+  } else {
+    console.log(`Can't convert canvas to image type of ${imageType}`);
   }
-
-  console.log(`Can't convert canvas to image type of ${imageType}`);
-
   return result;
 }
 

--- a/packages/static-cs-lite/lib/util/imageFrame/convert/color/convertRGBColorByPixel.js
+++ b/packages/static-cs-lite/lib/util/imageFrame/convert/color/convertRGBColorByPixel.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-plusplus, no-param-reassign */
-const assertArrayDivisibility = require("../../../assertArrayDivisibility");
 
 /**
  * Convert pixel data with RGB (by pixel) Photometric Interpretation to RGBA
@@ -9,11 +8,7 @@ const assertArrayDivisibility = require("../../../assertArrayDivisibility");
  * @returns {void}
  */
 function converter(imageFrame, rgbaBuffer) {
-  if (!assertArrayDivisibility(imageFrame, 3, ["decodeRGB: rgbBuffer must not be undefined", "decodeRGB: rgbBuffer length must be divisble by 3"])) {
-    return;
-  }
-
-  const numPixels = imageFrame.length / 3;
+  const numPixels = Math.floor(imageFrame.length / 3);
 
   let rgbIndex = 0;
 

--- a/packages/static-wado-creator/lib/writer/HashDataWriter.js
+++ b/packages/static-wado-creator/lib/writer/HashDataWriter.js
@@ -29,7 +29,7 @@ const HashDataWriter =
     });
     await writeStream.write(rawData);
     await writeStream.close();
-    return `${dirName}/${fileName}${gzip && ".gz"}`;
+    return `${dirName}/${fileName}`;
   };
 
 /**
@@ -38,7 +38,7 @@ const HashDataWriter =
 HashDataWriter.createHashPath = (data, options = {}) => {
   const { mimeType } = options;
   const isRaw = ArrayBuffer.isView(data);
-  const extension = (isRaw && ((mimeType && extensions[mimeType]) || ".raw")) || ".json";
+  const extension = isRaw ? (mimeType && extensions[mimeType]) || "" : ".json";
   const existingHash = data[Tags.DeduppedHash];
   const hashValue = (existingHash && existingHash.Value[0]) || hasher.hash(data);
   return {

--- a/packages/static-wado-creator/lib/writer/VideoWriter.js
+++ b/packages/static-wado-creator/lib/writer/VideoWriter.js
@@ -19,7 +19,7 @@ const VIDEO_TYPES = {
   // TODO - add the new multi-segment MPEG2 and H264 variants
 };
 
-const isVideo = (dataSet) => VIDEO_TYPES[dataSet.string(Tags.RawTransferSyntaxUID)];
+const isVideo = (value) => VIDEO_TYPES[(value && value.string) ? value.string(Tags.RawTransferSyntaxUID) : value];
 
 const VideoWriter = () =>
   async function run(id, dataSet) {


### PR DESCRIPTION
Converting thumbnails sometimes caused problems, as did some aspect ratio colour images.  Now both at least don't fail with exceptions, even if they don't generate thumbnails yet.