### PR TITLE
fix default missing pixel representation to 0

### DIFF
--- a/packages/static-cs-lite/lib/util/imageFrame/get/fromDataset.js
+++ b/packages/static-cs-lite/lib/util/imageFrame/get/fromDataset.js
@@ -20,7 +20,7 @@ function fromDataset(dataSet, decodedPixelData) {
     columns: dataSet.Columns,
     bitsAllocated: dataSet.BitsAllocated,
     bitsStored: dataSet.BitsStored,
-    pixelRepresentation: dataSet.PixelPresentation, // 0 = unsigned,
+    pixelRepresentation: dataSet.PixelPresentation || 0, // 0 = unsigned,
     smallestPixelValue: dataSet.SmallestImagePixelValue,
     largestPixelValue: dataSet.LargestImagePixelValue,
     bluePaletteColorLookupTableData,


### PR DESCRIPTION
It includes
- Default pixel representation to 0. It prevents down layers having wrong assumptions.