### PR TITLE
Feat/fix cache deploy s3

### DIFF
--- a/packages/static-wado-creator/lib/mkdicomwebConfig.js
+++ b/packages/static-wado-creator/lib/mkdicomwebConfig.js
@@ -9,6 +9,7 @@ const metadataMain = require("./metadataMain");
 
 /**
  * Defines the basic configuration values for the dicomwebserver component.  See the README for more details.
+ * TODO - fix the default values so they come from the configuration file.  In the meantime, leave the defaults blank.
  */
 const { mkdicomwebConfig } = ConfigPoint.register({
   mkdicomwebConfig: {
@@ -38,11 +39,6 @@ const { mkdicomwebConfig } = ConfigPoint.register({
         defaultValue: 128 * 1024 + 2,
       },
       {
-        key: "-o, --dir <value>",
-        description: "Set output directory",
-        defaultValue: "~/dicomweb", // defaults.rootDir,
-      },
-      {
         key: "-M, --maximum-inline-private-length <value>",
         description: "Maximum length of private binary data",
         defaultValue: 64,
@@ -51,13 +47,13 @@ const { mkdicomwebConfig } = ConfigPoint.register({
         key: "-r, --recompress <listvalue...>",
         description: "List of types to recompress separated by comma",
         defaultValue: ["uncompressed", "jp2"],
-        choices: ["uncompressed", "jp2", "jpeglossless", "rle"],
+        choices: ["uncompressed", "jp2", "jpeglossless", "rle", "none"],
       },
       {
         key: "--recompress-thumb <listvalue...>",
         description: "List of types to recompress thumb separated by comma",
         defaultValue: ["uncompressed", "jp2"],
-        choices: ["uncompressed", "jp2", "jpeglossless", "rle"],
+        choices: ["uncompressed", "jp2", "jpeglossless", "rle", "none"],
       },
       {
         key: "--no-recompress",
@@ -98,6 +94,11 @@ const { mkdicomwebConfig } = ConfigPoint.register({
         key: "--expand-bulk-data-uri",
         description: "expand bulkdata relative uri to use full relative path (should also be set when using --prepend-bulk-data-uri)",
         defaultValue: false,
+      },
+      {
+        key: "-o, --dir <value>",
+        description: "Set output directory",
+        defaultValue: { configOperation: "reference", source: "staticWadoConfig", reference: "rootDir" },
       },
     ],
     programs: [

--- a/packages/static-wado-creator/lib/model/TagLists.js
+++ b/packages/static-wado-creator/lib/model/TagLists.js
@@ -11,7 +11,17 @@ const { SeriesDescription, SeriesNumber, SeriesInstanceUID, SeriesDate, SeriesTi
 
 const { DeduppedCreator, DeduppedTag, DeduppedHash, DeduppedRef, DeduppedType } = Tags;
 
-const PatientQuery = [PatientID, PatientName, IssuerOfPatientID, Tags.PatientIdentityRemoved, Tags.DeidentificationMethodCodeSequence];
+const PatientQuery = [
+  PatientID,
+  Tags.OtherPatientIDsSequence,
+  PatientName,
+  IssuerOfPatientID,
+  Tags.PatientBirthDate,
+  Tags.PatientBirthTime,
+  Tags.PatientSex,
+  Tags.PatientIdentityRemoved,
+  Tags.DeidentificationMethodCodeSequence,
+];
 const StudyQuery = [StudyDescription, AccessionNumber, StudyInstanceUID, StudyDate, StudyTime, Tags.StudyStatusID, Tags.StudyPriorityID, Tags.StudyID];
 
 const PatientStudyQuery = [...PatientQuery, ...StudyQuery];
@@ -26,6 +36,7 @@ const SeriesExtract = [
   SeriesDate,
   SeriesTime,
   Tags.SpecificCharacterSet,
+  Tags.Manufacturer,
   Tags.InstitutionName,
   Tags.ReferringPhysicianName,
   Tags.StationName,

--- a/packages/static-wado-creator/lib/writer/ExpandUriPath.js
+++ b/packages/static-wado-creator/lib/writer/ExpandUriPath.js
@@ -3,7 +3,7 @@ const ExpandUriPath = (id, path, options) => {
   let expandedRelative = "";
   if (expandBulkDataUri) {
     let expandedRelativeSeries = "";
-    if(includeSeries) {
+    if (includeSeries) {
       expandedRelativeSeries = `series/${id.seriesInstanceUid}/`;
     }
     expandedRelative = `studies/${id.studyInstanceUid}/${expandedRelativeSeries}`;

--- a/packages/static-wado-creator/lib/writer/HashDataWriter.js
+++ b/packages/static-wado-creator/lib/writer/HashDataWriter.js
@@ -20,8 +20,7 @@ let first = true;
 const HashDataWriter =
   (options) =>
   async (id, key, data, additionalOptions = {}) => {
-
-    if(first) {
+    if (first) {
       console.log("HashDataWriter - options: ", options);
       console.log("HashDataWriter - additional options: ", additionalOptions);
       first = false;

--- a/packages/static-wado-creator/lib/writer/ImageFrameWriter.js
+++ b/packages/static-wado-creator/lib/writer/ImageFrameWriter.js
@@ -24,7 +24,7 @@ const ImageFrameWriter = (options) => {
     await writeStream.close();
     if (verbose) console.log("Wrote image frame", id.sopInstanceUid, index + 1);
     const includeSeries = true;
-    return ExpandUriPath(id, `instances/${id.sopInstanceUid}/frames`, { includeSeries, ...options});
+    return ExpandUriPath(id, `instances/${id.sopInstanceUid}/frames`, { includeSeries, ...options });
   };
 };
 

--- a/packages/static-wado-creator/lib/writer/MultipartAttribute.js
+++ b/packages/static-wado-creator/lib/writer/MultipartAttribute.js
@@ -1,0 +1,8 @@
+class MultipartAttribute {
+  constructor(attributeName, attributeValue) {
+    this.attributeName = attributeName;
+    this.attributeValue = attributeValue;
+  }
+}
+
+module.exports = MultipartAttribute;

--- a/packages/static-wado-creator/lib/writer/MultipartHeader.js
+++ b/packages/static-wado-creator/lib/writer/MultipartHeader.js
@@ -1,9 +1,4 @@
-class MultipartAttribute{
-  constructor(attributeName, attributeValue) {
-    this.attributeName = attributeName;
-    this.attributeValue = attributeValue;
-  }
-}
+const MultipartAttribute = require("./MultipartAttribute");
 
 class MultipartHeader {
   constructor(headerName, headerValue, attributes = []) {
@@ -15,5 +10,5 @@ class MultipartHeader {
 
 module.exports = {
   MultipartAttribute,
-  MultipartHeader
-}
+  MultipartHeader,
+};

--- a/packages/static-wado-creator/lib/writer/WriteMultipart.js
+++ b/packages/static-wado-creator/lib/writer/WriteMultipart.js
@@ -1,4 +1,4 @@
-const { v4: uuid } = require('uuid');
+const { v4: uuid } = require("uuid");
 
 const WriteMultipart = async (writeStream, headers, content) => {
   const boundaryId = uuid();
@@ -6,7 +6,7 @@ const WriteMultipart = async (writeStream, headers, content) => {
   for (let i = 0; i < headers.length; i++) {
     const header = headers[i];
     await writeStream.write(`${header.headerName}: ${header.headerValue}`);
-    if(header.attributes) {
+    if (header.attributes) {
       for (let j = 0; j < header.attributes.length; j++) {
         const attribute = header.attributes[j];
         await writeStream.write(`;${attribute.attributeName}=${attribute.attributeValue}`);

--- a/packages/static-wado-deploy/lib/DeployGroup.mjs
+++ b/packages/static-wado-deploy/lib/DeployGroup.mjs
@@ -13,9 +13,10 @@ import { plugins } from "@radical/static-wado-plugins";
  */
 
 class DeployGroup {
-  constructor(config, groupName) {
+  constructor(config, groupName, options) {
     this.config = config;
     this.groupName = groupName;
+    this.options = options;
     this.group = configGroup(config, groupName);
     this.baseDir = handleHomeRelative(this.group.dir);
   }
@@ -24,7 +25,7 @@ class DeployGroup {
   async loadOps() {
     const imported = await import(plugins[this.config.deployPlugin || "s3Plugin"]);
     const { createPlugin: CreatePlugin } = imported.default || imported;
-    this.ops = new CreatePlugin(this.config, this.groupName);
+    this.ops = new CreatePlugin(this.config, this.groupName, this.options);
   }
 
   /**

--- a/packages/static-wado-deploy/lib/clientMain.js
+++ b/packages/static-wado-deploy/lib/clientMain.js
@@ -1,10 +1,8 @@
 import DeployGroup from "./DeployGroup.mjs";
 
-export default async function () {
+export default async function (options) {
   console.log("Deploy studies", this.deployPlugin);
-  const deployer = new DeployGroup(this, "client");
+  const deployer = new DeployGroup(this, "client", options);
   await deployer.loadOps();
-  console.log("Loaded operations");
   await deployer.store();
-  console.log("Stored");
 }

--- a/packages/static-wado-deploy/lib/deployConfig.js
+++ b/packages/static-wado-deploy/lib/deployConfig.js
@@ -20,6 +20,19 @@ const { deployConfig } = ConfigPoint.register({
     // This declare the inheritted configuration, don't assume this is directly accessible
     configBase: staticWadoConfig,
 
+    options: [
+      {
+        key: "--dry-run",
+        description: "Do a dry run, without actually uploading (but DOES check remote existance if configured)",
+        defaultValue: false,
+      },
+      {
+        key: "-v, --verbose",
+        description: "Write verbose output",
+        defaultValue: false,
+      },
+    ],
+
     programs: [
       {
         command: "studies",

--- a/packages/static-wado-deploy/lib/deployConfig.js
+++ b/packages/static-wado-deploy/lib/deployConfig.js
@@ -2,6 +2,7 @@ import ConfigPoint from "config-point";
 import { staticWadoConfig } from "@radical/static-wado-util";
 import studiesMain from "./studiesMain.js";
 import clientMain from "./clientMain.js";
+import themeMain from "./themeMain.js";
 
 // Define the generic configuration in the base config
 ConfigPoint.extendConfiguration("staticWadoConfig", {
@@ -43,11 +44,17 @@ const { deployConfig } = ConfigPoint.register({
       },
       {
         command: "client",
-        argument: ["<string>", "Study UID to deploy"],
         helpShort: "deploydicomweb client",
         helpDescription: "Deploy client files to the cloud",
         main: clientMain,
       },
+      {
+        command: "theme",
+        helpShort: "deploydicomweb theme",
+        helpDescription: "Deploy updated theme files to the cloud",
+        main: themeMain,
+      },
+
       // {
       //   command: "continuous",
       //   helpShort: "deploydicomweb continuous",

--- a/packages/static-wado-deploy/lib/program/index.mjs
+++ b/packages/static-wado-deploy/lib/program/index.mjs
@@ -10,6 +10,7 @@ import "../index.mjs";
 async function configureProgram(defaults = {}) {
   const configurationFile = await staticWadoUtil.loadConfiguration(defaults, process.argv);
   console.log("Loaded configuration from", configurationFile);
+  defaults.configurationFile = configurationFile;
   staticWadoUtil.configureCommands(defaults);
 }
 

--- a/packages/static-wado-deploy/lib/studiesMain.js
+++ b/packages/static-wado-deploy/lib/studiesMain.js
@@ -1,8 +1,8 @@
 import DeployGroup from "./DeployGroup.mjs";
 
-export default async function () {
+export default async function (options) {
   console.log("Deploy studies", this.deployPlugin);
-  const deployer = new DeployGroup(this, "root");
+  const deployer = new DeployGroup(this, "root", options);
   await deployer.loadOps();
   console.log("Loaded operations");
   await deployer.store("studies");

--- a/packages/static-wado-deploy/lib/themeMain.js
+++ b/packages/static-wado-deploy/lib/themeMain.js
@@ -1,0 +1,8 @@
+import DeployGroup from "./DeployGroup.mjs";
+
+export default async function (options) {
+  console.log("Deploy updated themes", this.deployPlugin);
+  const deployer = new DeployGroup(this, "client", options);
+  await deployer.loadOps();
+  await deployer.store("theme");
+}


### PR DESCRIPTION
The root files for the OHIF deployment, as well as the studies query for dicomweb were previously set to cache for a long time on the cloudfront endpoint, causing problems redeploying new versions.  This version fixes this - it assumes an earlier PR is committed first.