### PR TITLE
Update usage docs to ensure `index.json.gz` files are read

### DIFF
--- a/packages/static-wado-creator/README.md
+++ b/packages/static-wado-creator/README.md
@@ -158,10 +158,12 @@ There is currently no notification of what studies have been updated between sta
 ### To Serve Instances As a Web Server
 ```
 cd ~/dicomweb
-npx http-server -p 5000 -g --cors
+npx http-server -p 5000 -g --cors -e json
 ```
 
 The -g option serves up compressed files ending in .gz as compressed http streams.
+
+The -e option will mark json files as the default extension, so when requesting `GET dicomweb/studies/` the `./studies/index.json.gz` file will be served.
 
 ### To Create DICOM part 10 from DICOMweb files
 TODO


### PR DESCRIPTION
When running the command `npx http-server -p 5000 -g --cors` when the DICOMWeb request is made to `GET /studies` a directory listing is displayed as `index.html` does not exist.

Adding the option `-e json` will make sure the directory listing isn't shown but instead the `index.json.gz` will be returned.