### PR TITLE
fix(reject): Make the reject work again after recent changes

### DIFF
--- a/packages/static-wado-creator/lib/StaticWado.js
+++ b/packages/static-wado-creator/lib/StaticWado.js
@@ -64,10 +64,8 @@ class StaticWado {
    *
    * @param {string} args listing the instances to remove (may remove entire series)
    */
-  async reject(args) {
-    args.forEach((removal) => {
-      this.callback.reject(removal);
-    });
+  async reject(studyUID, seriesUID, reason) {
+      this.callback.reject(studyUID, seriesUID, reason);
   }
 
   /**

--- a/packages/static-wado-creator/lib/mkdicomwebConfig.js
+++ b/packages/static-wado-creator/lib/mkdicomwebConfig.js
@@ -174,9 +174,9 @@ const { mkdicomwebConfig } = ConfigPoint.register({
         helpDescription: "Delete the given study, series or instance (not yet implemented)",
       },
       {
-        command: "reject",
+        command: "reject <studyUID...>",
         main: rejectMain,
-        helpDescription: "Reject the specified series, specified as studies/<studyUID>/series/<seriesUID>",
+        helpDescription: "Reject the specified series",
       },
     ],
   },

--- a/packages/static-wado-creator/lib/operation/ScanStudy.js
+++ b/packages/static-wado-creator/lib/operation/ScanStudy.js
@@ -4,11 +4,11 @@ function ScanStudy(options) {
   const { directoryName, deduplicatedRoot, deduplicatedInstancesRoot } = options;
 
   return function scanStudy(studyInstanceUid) {
-    console.log("scanStudy", studyInstanceUid);
+    console.verbose("scanStudy", studyInstanceUid);
     const studyPath = path.join(directoryName, "studies", studyInstanceUid);
     const deduplicatedInstancesPath = path.join(deduplicatedInstancesRoot, studyInstanceUid);
     const deduplicatedPath = path.join(deduplicatedRoot, studyInstanceUid);
-    console.log("Importing", studyInstanceUid, studyPath, deduplicatedInstancesPath, deduplicatedPath);
+    console.verbose("Importing", studyInstanceUid, studyPath, deduplicatedInstancesPath, deduplicatedPath);
     return this.completeStudy.getCurrentStudyData(this, {
       studyPath,
       deduplicatedPath,

--- a/packages/static-wado-creator/lib/operation/StudyData.js
+++ b/packages/static-wado-creator/lib/operation/StudyData.js
@@ -60,7 +60,10 @@ class StudyData {
     const info = studyDeduplicated[0];
     if( info ) {
       const hash = getValue(info,Tags.DeduppedHash);
+      console.log("Reading studies/<studyUID>/deduplicated/index.json.gz");
       this.readDeduplicatedData("index.json.gz", studyDeduplicated, hash);
+    } else {
+      console.log("No deduplicated/index.json to read in", this.studyPath, "/deduplicated/index.json.gz");
     }
     if (this.deduplicatedPath) {
       this.groupFiles = await this.readDeduplicated(this.deduplicatedPath);
@@ -111,7 +114,7 @@ class StudyData {
   }
 
   async reject(seriesInstanceUid, sopInstanceUid, reason) {
-    console.log("Rejecting series instance UID", seriesInstanceUid, "because", reason);
+    console.log("Rejecting", this.studyInstanceUid, seriesInstanceUid, "because", reason);
     // TODO - actually add a reject note...
     this.newInstancesAdded += 1;
     for (let i = 0; i < this.deduplicated.length; i++) {

--- a/packages/static-wado-creator/lib/rejectMain.js
+++ b/packages/static-wado-creator/lib/rejectMain.js
@@ -1,12 +1,12 @@
 const StaticWado = require("./StaticWado");
 const adaptProgramOpts = require("./util/adaptProgramOpts");
 
-module.exports = function rejectMain(options, program) {
+module.exports = function rejectMain(args, options) {
   const finalOptions = adaptProgramOpts(options, {
     ...this,
     isGroup: true,
     isStudyData: true,
   });
   const importer = new StaticWado(finalOptions);
-  return importer.reject(program.args);
+  return importer.reject(args);
 };

--- a/packages/static-wado-plugins/package.json
+++ b/packages/static-wado-plugins/package.json
@@ -30,6 +30,9 @@
   "homepage": "https://github.com/OHIF/static-wado#readme",
   "license": "ISC",
   "main": "lib/index.js",
+  "export": {
+    ".": "./lib/index.js"
+  },
   "directories": {
     "lib": "lib"
   },

--- a/packages/static-wado-util/lib/dictionary/Tags.js
+++ b/packages/static-wado-util/lib/dictionary/Tags.js
@@ -53,6 +53,7 @@ const Tags = {
   // Type of hash instance
   DeduppedType: { creator: DeduppedCreator, tag: "00091012" },
   InstanceType: "instance",
+  DeletedType: "deleted",
   InfoType: "info",
 
   naturalizeDataset,


### PR DESCRIPTION
The reject wasn't working on more than one series, nor on multiple instances due to not loading the reject correctly, as well as due to a parameter change causing a wrong path to be loaded.