### PR TITLE
Add dcm2jpg based thumbnail and rendered generator

### DIFF
--- a/packages/static-wado-creator/lib/StaticWado.js
+++ b/packages/static-wado-creator/lib/StaticWado.js
@@ -198,8 +198,8 @@ class StaticWado {
     await this.callback.rawDicomWriter?.(id, result, buffer);
 
     const transcodedMeta = transcodeMetadata(result.metadata, id, this.options);
-    await thumbnailService.generateThumbnails(id, dataSet, transcodedMeta, this.callback);
-
+    await thumbnailService.generateThumbnails(id, dataSet, transcodedMeta, this.callback, this.options);
+    await thumbnailService.generateRendered(id, dataSet, transcodedMeta, this.callback, this.options);
     await this.callback.metadata(targetId, transcodedMeta);
 
     // resolve promise with statistics

--- a/packages/static-wado-creator/lib/mkdicomwebConfig.js
+++ b/packages/static-wado-creator/lib/mkdicomwebConfig.js
@@ -110,6 +110,20 @@ const { mkdicomwebConfig } = ConfigPoint.register({
         defaultValue: false,
       },
       {
+        key: "--no-thumb",
+        description: "Skip thumbnail generation",
+      },
+      {
+        key: "--dcm2jpg",
+        description: "Use dcm2jpg for thumbnail image generation",
+        defaultValue: false,
+      },
+      {
+        key: "--rendered",
+        description: "Use dcm2jpg to generate a rendered PNG image",
+        defaultValue: false,
+      },
+      {
         key: "-T, --color-content-type <value>",
         description: "Colour content type",
         defaultValue: "jpeg",

--- a/packages/static-wado-creator/lib/operation/ThumbnailService.js
+++ b/packages/static-wado-creator/lib/operation/ThumbnailService.js
@@ -80,6 +80,26 @@ class ThumbnailService {
     execSpawn(`ffmpeg -i "${input}" -vf  "thumbnail,scale=640:360" -frames:v 1 -f singlejpeg "${output}"`);
   }
 
+  dcm2jpg(input, output, options) {
+    const script = ["dcm2jpg", `"${input}" "${output}"`];
+    if (options?.format) {
+      script.push("-F", options.format);
+    }
+    execSpawn(script.join(" "));
+  }
+
+  /** Generates a rendered copy of this, assuming --rendered is set.
+   * Requires dcm2jpg to be available.
+   */
+  async generateRendered(itemid, dataSet, metadata, callback, options) {
+    if (!options.rendered) {
+      return null;
+    }
+    const { id } = this.favoriteThumbnailObj;
+    const rendered = id.imageFrameRootPath.replace(/frames/, "rendered");
+    return this.dcm2jpg(id.filename, rendered, { format: "png" });
+  }
+
   /**
    * Generates thumbnails for the levels: instances, series, study.  This is asynchronous
    *
@@ -87,8 +107,12 @@ class ThumbnailService {
    * @param {*} metadata
    * @param {*} callback
    */
-  generateThumbnails(itemId, dataSet, metadata, callback) {
+  async generateThumbnails(itemId, dataSet, metadata, callback, options) {
     const { imageFrame, id } = this.favoriteThumbnailObj;
+
+    if (!options.thumb) {
+      return null;
+    }
 
     // There are various reasons no thumbnails might be generated, so just return
     if (!id) {
@@ -101,16 +125,20 @@ class ThumbnailService {
           const thumbPath = path.join(itemId.sopInstanceRootPath, "rendered");
           console.log("MP4 - converting video format", mp4Path);
           this.ffmpeg(mp4Path, thumbPath);
-        } else {
-          console.log("pixelData = ", pixelData, Tags.PixelData);
+          return thumbPath;
         }
       } else {
         console.log("Series is of other type...", metadata[Tags.Modality]);
       }
       return null;
     }
-    return new Promise((resolve, reject) => {
-      callback.internalGenerateImage(imageFrame, dataSet, metadata, id.transferSyntaxUid, async (thumbBuffer) => {
+    if( options.dcm2jpg ) {
+      return this.dcm2jpg(id.filename, id.imageFrameRootPath.replace(/frames/,"thumbnail"), {});
+    }
+
+    console.log("Using CS2 to generate thumbnails", id, options);
+
+    await callback.internalGenerateImage(imageFrame, dataSet, metadata, id.transferSyntaxUid, async (thumbBuffer) => {
         try {
           if (thumbBuffer) {
             await callback.thumbWriter(id.sopInstanceRootPath, this.thumbFileName, thumbBuffer);
@@ -119,11 +147,11 @@ class ThumbnailService {
             this.copySyncThumbnail(id.seriesRootPath, id.studyPath);
             Stats.StudyStats.add("Thumbnail Write", `Write thumbnail ${this.thumbFileName}`, 100);
           }
-          resolve(this.thumbFileName);
-        } catch (e) {
-          reject(e);
+          return this.thumbFileName;
+        } catch(e) {
+          console.log("Couldn't generate thumbnail", this.thumbFileName, e);
         }
-      });
+
     });
   }
 

--- a/packages/static-wado-webserver/lib/adapters/requestAdapters.mjs
+++ b/packages/static-wado-webserver/lib/adapters/requestAdapters.mjs
@@ -30,6 +30,16 @@ export const thumbnailMap = (req, res, next) => {
   next();
 };
 
+
+/**
+ * Handles returning rendered png
+ */
+export const renderedMap = (req, res, next) => {
+  res.setHeader("content-type", "image/png");
+  req.url = `${req.path}`;
+  next();
+};
+
 /**
  * Handles returning multipart/related DICOM
  */

--- a/packages/static-wado-webserver/lib/routes/server/studies.mjs
+++ b/packages/static-wado-webserver/lib/routes/server/studies.mjs
@@ -1,5 +1,5 @@
 import { assertions } from "@radicalimaging/static-wado-util";
-import { qidoMap, dicomMap, otherJsonMap, thumbnailMap, multipartIndexMap, multipartMap } from "../../adapters/requestAdapters.mjs";
+import { qidoMap, dicomMap, otherJsonMap, thumbnailMap, multipartIndexMap, multipartMap, renderedMap } from "../../adapters/requestAdapters.mjs";
 import { defaultPostController as postController } from "../../controllers/server/commonControllers.mjs";
 import { defaultNotFoundController as notFoundController } from "../../controllers/server/notFoundControllers.mjs";
 import { defaultGetProxyController } from "../../controllers/server/proxyControllers.mjs";
@@ -17,6 +17,10 @@ export default function setRoutes(routerExpress, params, dir) {
   routerExpress.get(
     ["/studies/:studyUID/thumbnail", "/studies/:studyUID/series/:seriesUID/thumbnail", "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/thumbnail"],
     thumbnailMap
+  );
+  routerExpress.get(
+    ["/studies/:studyUID/rendered", "/studies/:studyUID/series/:seriesUID/rendered", "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/rendered"],
+    renderedMap
   );
   routerExpress.get(
     ["/:ae/studies/:studyUID/series/:seriesUID/instances/:instanceUID/frames/:frames", "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/frames/:frames"],


### PR DESCRIPTION
Adds options for:
--no-thumb
Prevents thumbnail generation

--rendered
Enables rendered view generation using dcm2jpg -F png  (must have dcm4che toolkit installed and on path)

--dcm2jpg
Enables using dcm2jpg for thumbnails instead of cornerstone