### PR TITLE
feat: lossy byte range retrieves and encoding separate items

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "@cornerstonejs/codec-openjpeg": "^1.2.2",
-    "@cornerstonejs/codec-openjph": "^2.4.2",
-    "@cornerstonejs/dicom-codec": "^0.1.9",
+    "@cornerstonejs/codec-openjpeg": ">=1.2.2",
+    "@cornerstonejs/codec-openjph": ">=2.4.3",
+    "@cornerstonejs/dicom-codec": ">=0.1.10",
     "canvas": "^2.11.0",
     "typescript": "^5.2.2"
   },

--- a/packages/static-wado-creator/lib/createPart10.js
+++ b/packages/static-wado-creator/lib/createPart10.js
@@ -13,7 +13,7 @@ const { DicomDict, DicomMetaDictionary } = dcmjs.data;
 const fileMetaInformationVersionArray = new Uint8Array(2);
 fileMetaInformationVersionArray[1] = 1;
 
-const createFmi = instance => {
+const createFmi = (instance) => {
   // Assume the TSUID is in the value 0
   const TransferSyntaxUID = Tags.getValue(instance, Tags.AvailableTransferSyntaxUID) || UncompressedLEIExplicit;
   const MediaStorageSOPClassUID = Tags.getValue(instance, Tags.MediaStorageSOPClassUID);
@@ -50,17 +50,17 @@ const readBulkDataValue = async (studyDir, instance, value) => {
 };
 
 const readBinaryData = async (dir, instance) => {
-  for(const tag of Object.keys(instance)) {
+  for (const tag of Object.keys(instance)) {
     const v = instance[tag];
-    if( v.BulkDataURI ) {
+    if (v.BulkDataURI) {
       await readBulkDataValue(dir, instance, v);
       continue;
     }
     if (!v.vr) {
       const value0 = v.Value?.[0];
       if (typeof value0 === "string") {
-        v.vr = 'LT';
-      } else { 
+        v.vr = "LT";
+      } else {
         console.log("Deleting", tag, v.Value, v);
         delete instance[tag];
       }

--- a/packages/static-wado-creator/lib/mkdicomwebConfig.js
+++ b/packages/static-wado-creator/lib/mkdicomwebConfig.js
@@ -53,7 +53,7 @@ const { mkdicomwebConfig } = ConfigPoint.register({
       {
         key: "--alternate <type>",
         description: "Generates an alternate representaton of the image generally in the /lossy sub-directory",
-        choices: ["jhc", "jls"],
+        choices: ["jhc", "jls", "jhcLossless", "jlsLossless"],
       },
       {
         key: "--alternate-thumbnail",

--- a/packages/static-wado-creator/lib/mkdicomwebConfig.js
+++ b/packages/static-wado-creator/lib/mkdicomwebConfig.js
@@ -60,6 +60,11 @@ const { mkdicomwebConfig } = ConfigPoint.register({
         description: "Generates a thumbnail for the alternate representation",
       },
       {
+        key: "--alternate-name <dir>",
+        description: "Uses a given sub directory name",
+        defaultValue: 'lossy',
+      },
+      {
         key: "-v, --verbose",
         description: "Write verbose output",
         defaultValue: false,

--- a/packages/static-wado-creator/lib/mkdicomwebConfig.js
+++ b/packages/static-wado-creator/lib/mkdicomwebConfig.js
@@ -46,6 +46,20 @@ const { mkdicomwebConfig } = ConfigPoint.register({
         defaultValue: false,
       },
       {
+        key: "--lossy",
+        description: "Generate lossy instances instead of lossless",
+        defaultValue: false,
+      },
+      {
+        key: "--alternate <type>",
+        description: "Generates an alternate representaton of the image generally in the /lossy sub-directory",
+        choices: ["jhc", "jls"],
+      },
+      {
+        key: "--alternate-thumbnail",
+        description: "Generates a thumbnail for the alternate representation",
+      },
+      {
         key: "-v, --verbose",
         description: "Write verbose output",
         defaultValue: false,
@@ -180,8 +194,7 @@ const { mkdicomwebConfig } = ConfigPoint.register({
         command: "part10",
         arguments: ["studyUID"],
         main: createPart10,
-        helpDescription:
-          "Store the specified study as part 10 data",
+        helpDescription: "Store the specified study as part 10 data",
       },
       {
         command: "index",

--- a/packages/static-wado-creator/lib/operation/ThumbnailService.js
+++ b/packages/static-wado-creator/lib/operation/ThumbnailService.js
@@ -132,26 +132,23 @@ class ThumbnailService {
       }
       return null;
     }
-    if( options.dcm2jpg ) {
-      return this.dcm2jpg(id.filename, id.imageFrameRootPath.replace(/frames/,"thumbnail"), {});
+    if (options.dcm2jpg) {
+      return this.dcm2jpg(id.filename, id.imageFrameRootPath.replace(/frames/, "thumbnail"), {});
     }
 
-    console.log("Using CS2 to generate thumbnails", id, options);
-
     await callback.internalGenerateImage(imageFrame, dataSet, metadata, id.transferSyntaxUid, async (thumbBuffer) => {
-        try {
-          if (thumbBuffer) {
-            await callback.thumbWriter(id.sopInstanceRootPath, this.thumbFileName, thumbBuffer);
+      try {
+        if (thumbBuffer) {
+          await callback.thumbWriter(id.sopInstanceRootPath, this.thumbFileName, thumbBuffer);
 
-            this.copySyncThumbnail(id.sopInstanceRootPath, id.seriesRootPath);
-            this.copySyncThumbnail(id.seriesRootPath, id.studyPath);
-            Stats.StudyStats.add("Thumbnail Write", `Write thumbnail ${this.thumbFileName}`, 100);
-          }
-          return this.thumbFileName;
-        } catch(e) {
-          console.log("Couldn't generate thumbnail", this.thumbFileName, e);
+          this.copySyncThumbnail(id.sopInstanceRootPath, id.seriesRootPath);
+          this.copySyncThumbnail(id.seriesRootPath, id.studyPath);
+          Stats.StudyStats.add("Thumbnail Write", `Write thumbnail ${this.thumbFileName}`, 100);
         }
-
+        return this.thumbFileName;
+      } catch (e) {
+        console.log("Couldn't generate thumbnail", this.thumbFileName, e);
+      }
     });
   }
 

--- a/packages/static-wado-creator/lib/operation/adapter/transcodeImage.js
+++ b/packages/static-wado-creator/lib/operation/adapter/transcodeImage.js
@@ -188,7 +188,7 @@ function transcodeLog(options, msg, error = "") {
 
 const beforeEncode = (options, encoder) => {
   const lossy = !!options.lossy;
-  const quality = lossy ? 0.00015 : -1;
+  const quality = lossy ? 0.002 : -1;
   const delta = lossy ? 3 : 0;
   // First value is to encode as reversible lossless colour
   encoder.setQuality?.(!lossy, quality);
@@ -235,8 +235,8 @@ function scale(imageFrame, imageInfo) {
  * In either case, saves it to <sopUID>/fsiz/frameNo as multipart related
  */
 async function generateLossyImage(id, decoded, options) {
-  if( !options.alternate ) return;
-  if( !decoded?.imageFrame ) return;
+  if (!options.alternate) return;
+  if (!decoded?.imageFrame) return;
 
   try {
     let { imageFrame, imageInfo } = decoded;
@@ -245,7 +245,7 @@ async function generateLossyImage(id, decoded, options) {
       imageFrameRootPath: id.imageFrameRootPath.replace('frames', options.alternateName),
       transferSyntaxUid: transcodeDestinationMap.jhc.transferSyntaxUid,
     };
-    
+
     let lossy = true;
     if (options.alternateThumbnail && imageInfo.rows >= 512) {
       const scaled = scale(imageFrame, imageInfo);
@@ -256,13 +256,13 @@ async function generateLossyImage(id, decoded, options) {
       imageFrame = Buffer.from(scaled.imageFrame.buffer);
       imageInfo = scaled.imageInfo;
     }
-    
-    if( options.alternate==="jls" ) {
+
+    if (options.alternate === "jls") {
       lossyId.transferSyntaxUid = transcodeDestinationMap["jls-lossy"].transferSyntaxUid;
-    } else if( options.alternate==="jlsLossless") {
-      lossyId.transferSyntaxUid = transcodeDestinationMap["jls-lossy"].transferSyntaxUid;
+    } else if (options.alternate === "jlsLossless") {
+      lossyId.transferSyntaxUid = transcodeDestinationMap.jls.transferSyntaxUid;
       lossy = false;
-    } else if( options.alternate==="jhcLossless") {
+    } else if (options.alternate === "jhcLossless") {
       lossy = false;
     }
 
@@ -273,6 +273,7 @@ async function generateLossyImage(id, decoded, options) {
     };
     const lossyEncoding = await dicomCodec.encode(imageFrame, imageInfo, lossyId.transferSyntaxUid, encodeOptions);
     console.log("Encoded alternate", lossyId.transferSyntaxUid, "of size", lossyEncoding.imageFrame.length);
+    // eslint-disable-next-line consistent-return
     return { id: lossyId, imageFrame: lossyEncoding.imageFrame };
   } catch(e) {
     console.warn("Unable to create alternate:",e);

--- a/packages/static-wado-creator/lib/writer/HashDataWriter.js
+++ b/packages/static-wado-creator/lib/writer/HashDataWriter.js
@@ -16,18 +16,17 @@ const extensions = {
 };
 
 const baseHasher = hashFactory.hasher();
-const MAX_HASH = 1024*1024;
+const MAX_HASH = 1024 * 1024;
 
 const hasher = {
   hash: (v) => {
     const type = v.constructor?.name;
     if (type === "Buffer") {
-      return createHash('sha256').update(v).digest('hex');
+      return createHash("sha256").update(v).digest("hex");
     }
     return baseHasher.hash(v);
   },
 };
-
 
 /** Writes out JSON files to the given file name.  Automatically GZips them, and adds the extension */
 const HashDataWriter =

--- a/packages/static-wado-creator/package.json
+++ b/packages/static-wado-creator/package.json
@@ -55,7 +55,7 @@
     "verbose": true
   },
   "dependencies": {
-    "@cornerstonejs/dicom-codec": ">=0.1.6",
+    "@cornerstonejs/dicom-codec": ">=0.1.10",
     "@radicalimaging/static-cs-lite": ">=1.2.1",
     "@radicalimaging/static-wado-util": ">=1.2.1",
     "canvas": "^2.11.0",

--- a/packages/static-wado-util/lib/image/bilinear.js
+++ b/packages/static-wado-util/lib/image/bilinear.js
@@ -1,0 +1,55 @@
+/**
+ * Performs a bilinear scaling, both scaling up and scaling down.
+ * @param src - src image frame to get map from
+ * @param dest - dest image frame to write to
+ * @returns destination data buffer
+ */
+function bilinear(src, dest) {
+  const { rows: srcRows, columns: srcColumns, data: srcData } = src;
+  const { rows, columns, data } = dest;
+
+  const xSrc1Off = [];
+  const xSrc2Off = [];
+  const xFrac = [];
+
+  // Precompute offsets
+  for (let x = 0; x < columns; x++) {
+    const xSrc = (x * (srcColumns - 1)) / (columns - 1);
+    xSrc1Off[x] = Math.floor(xSrc);
+    xSrc2Off[x] = Math.min(xSrc1Off[x] + 1, srcColumns - 1);
+    xFrac[x] = xSrc - xSrc1Off[x];
+    // console.log("x src info", x, xSrc, xFrac[x]);
+  }
+
+  for (let y = 0; y < rows; y++) {
+    const ySrc = (y * (srcRows - 1)) / (rows - 1);
+    const ySrc1Off = Math.floor(ySrc) * srcColumns;
+    // Get the second offset, but duplicate the last row so the lookup works
+    const ySrc2Off = Math.min(ySrc1Off + srcColumns, (srcRows - 1) * srcColumns);
+    const yFrac = ySrc - Math.floor(ySrc);
+    const yFracInv = 1 - yFrac;
+    const yOff = y * columns;
+    // console.log("yfrac", y, ySrc, yFrac, yFracInv);
+
+    for (let x = 0; x < columns; x++) {
+      // TODO - put the pXY into the data calculation
+      const p00 = srcData[ySrc1Off + xSrc1Off[x]];
+      const p10 = srcData[ySrc1Off + xSrc2Off[x]];
+      const p01 = srcData[ySrc2Off + xSrc1Off[x]];
+      const p11 = srcData[ySrc2Off + xSrc2Off[x]];
+      const xFracInv = 1 - xFrac[x];
+
+    //   console.log("bilinear for", x,y, "from", ySrc1Off + xSrc1Off[x], ySrc1Off + xSrc2Off[x], ySrc2Off + xSrc1Off[x], ySrc2Off + xSrc2Off[x]);
+    //   console.log("values", p00, p10, p01, p11);
+    //   console.log("fractions", xFracInv, xFrac[x], yFracInv, yFrac);
+
+      data[yOff + x] = (p00 * xFracInv + p10 * xFrac[x]) * yFracInv + (p01 * xFracInv + p11 * xFrac[x]) * yFrac;
+    }
+  }
+  return data;
+}
+
+module.exports = {
+  bilinear,
+  default: bilinear,
+};

--- a/packages/static-wado-util/lib/index.js
+++ b/packages/static-wado-util/lib/index.js
@@ -1,5 +1,7 @@
 const { program, configureProgram, configureCommands } = require("./program");
 const { Stats } = require("./stats");
+const { bilinear, replicate } = require("./image/bilinear");
+
 exports.handleHomeRelative = require("./handleHomeRelative");
 exports.JSONReader = require("./reader/JSONReader");
 exports.NDJSONReader = require("./reader/NDJSONReader");
@@ -22,6 +24,8 @@ exports.endsWith = require("./endsWith");
 exports.NotificationService = require("./NotificationService");
 exports.execSpawn = require("./execSpawn");
 
+exports.bilinear = bilinear;
+exports.replicate = replicate;
 exports.configureProgram = configureProgram;
 exports.configureCommands = configureCommands;
 exports.program = program;

--- a/packages/static-wado-util/lib/reader/readBulkData.js
+++ b/packages/static-wado-util/lib/reader/readBulkData.js
@@ -54,7 +54,7 @@ const getSeparator = (data) => {
   }
   const endSeparator = findIndexOfString(data, "\r\n", 0);
   if (!endSeparator) {
-    console.log("No end to separator", String(data.slice(0,55)));
+    console.log("No end to separator", String(data.slice(0, 55)));
     return null;
   }
   const separator = data.slice(0, endSeparator);

--- a/packages/static-wado-util/tests/unit/bilinear.test.js
+++ b/packages/static-wado-util/tests/unit/bilinear.test.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-use-before-define */
+const must = require("must");
+const { bilinear } = require("../../lib/image/bilinear");
+
+describe("bilinear tests", () => {
+
+  it("identityTransform", async () => {
+    const src = createImage(5,7);
+    for (let y = 0; y < src.rows; y++) {
+      for (let x = 0; x < src.columns; x++) {
+        src.data[y * src.columns + x] = y * src.columns + x;
+      }
+    }
+    const dest = createImage(5,7);
+    bilinear(src,dest);
+    for (let y = 0; y < src.rows; y++) {
+      for (let x = 0; x < src.columns; x++) {
+        must(dest.data[y * src.columns + x]).be.equal(y * src.columns + x);
+      }
+    }  
+  });
+
+  it("fixedScale", async () => {
+    const src = createImage(2,2);
+    src.data[0] = 5;
+    src.data[1] = 12;
+    src.data[2] = 65_535;
+    src.data[3] = 32_768;
+    const dest = createImage(3, 5);
+    bilinear(src, dest);
+    must(dest.data[0]).equal(src.data[0]);
+    must(dest.data[1]).equal(Math.floor(src.data[0] / 2 + src.data[1] / 2));
+    must(dest.data[3]).equal(Math.floor(src.data[0] * 0.75 + src.data[2] * 0.25));
+    must(dest.data[4]).equal(Math.floor(src.data[0] * 0.75 / 2 + src.data[1] * 0.75 /2 + src.data[2] * 0.25 / 2 + src.data[3] * 0.25 / 2));
+  });
+});
+
+function createImage(columns, rows) {
+  return {
+    rows,
+    columns,
+    data: new Uint16Array(columns * rows),
+  };
+}

--- a/packages/static-wado-util/tests/unit/bilinear.test.js
+++ b/packages/static-wado-util/tests/unit/bilinear.test.js
@@ -39,6 +39,6 @@ function createImage(columns, rows) {
   return {
     rows,
     columns,
-    data: new Uint16Array(columns * rows),
+    pixelData: new Uint16Array(columns * rows),
   };
 }

--- a/packages/static-wado-webserver/lib/adapters/requestAdapters.mjs
+++ b/packages/static-wado-webserver/lib/adapters/requestAdapters.mjs
@@ -30,7 +30,6 @@ export const thumbnailMap = (req, res, next) => {
   next();
 };
 
-
 /**
  * Handles returning rendered png
  */

--- a/packages/static-wado-webserver/lib/controllers/server/byteRangeRequest.mjs
+++ b/packages/static-wado-webserver/lib/controllers/server/byteRangeRequest.mjs
@@ -1,0 +1,58 @@
+import { handleHomeRelative } from "@radicalimaging/static-wado-util";
+import fs from "fs";
+
+const extensions = {
+  "image/jphc": ".jhc",
+  "image/jpeg": ".jpeg",
+};
+
+export default function byteRangeRequest(options) {
+  const { dir } = options;
+  const baseDir = handleHomeRelative(dir);
+
+  
+  function exists(path, frameName) {
+    const framePath = path.replace("/frames/",`/${frameName}/`);
+    const fullPath = `${baseDir}/${framePath}`;
+    return fs.existsSync(fullPath);
+  }
+
+  async function rangeResponse(req,res,range) {
+    // Better hope the range is a simple - range
+    const bytes = range.substring(6).split('-');
+    const path = `${baseDir}/${req.path}`;
+    if( !fs.existsSync(path) ) {
+        res.status(400).text("Not found");
+        return;
+    }
+    console.log("Generating response from", bytes[0], "to", bytes[1], "for", path);
+    const rawdata = await fs.promises.readFile(path);
+    const data = rawdata.slice(bytes[0], bytes[1]);
+    res.setHeader("content-type", "multipart/related");
+    res.status(206).send(data);
+  }
+
+  return (req, res, next) => {
+    const fsiz = req.query.fsiz;
+    const range = req.header("Range");
+    if (fsiz && exists(req.path, `fsiz`)) {
+      req.url = req.path.replace("/frames/", "/fsiz/");
+      console.log("Using fsiz relative directory for fractional sizes", req.url);
+    } else if (range) {
+      console.log("Returning byte range request", range, req.path);
+      return rangeResponse(req,res,range);
+    }
+    const accept = req.header("accept") || "";
+    const queryAccept = req.query.accept;
+    const extension = extensions[queryAccept || accept];
+    if (extension) {
+      res.setHeader("content-type", queryAccept || accept);
+      req.url = `${req.path}${extension}`;
+    } else {
+      res.setHeader("content-type", "multipart/related");
+    }
+    next();
+  };
+};
+
+

--- a/packages/static-wado-webserver/lib/controllers/server/byteRangeRequest.mjs
+++ b/packages/static-wado-webserver/lib/controllers/server/byteRangeRequest.mjs
@@ -21,14 +21,19 @@ export default function byteRangeRequest(options) {
     // Better hope the range is a simple - range
     const bytes = range.substring(6).split('-');
     const path = `${baseDir}/${req.path}`;
-    if( !fs.existsSync(path) ) {
-        res.status(400).text("Not found");
-        return;
+    if (!fs.existsSync(path)) {
+      res.status(400).text("Not found");
+      return;
     }
-    console.log("Generating response from", bytes[0], "to", bytes[1], "for", path);
     const rawdata = await fs.promises.readFile(path);
+    const { length } = rawdata;
+    bytes[0] ||= 0;
+    bytes[1] ||= length;
+    bytes[1] = Math.min(bytes[1], length);
     const data = rawdata.slice(bytes[0], bytes[1]);
     res.setHeader("content-type", "multipart/related");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Range");
+    res.setHeader("Content-Range", `${bytes[0]}-${bytes[1]}/${length}`);
     res.status(206).send(data);
   }
 

--- a/packages/static-wado-webserver/lib/routes/server/studies.mjs
+++ b/packages/static-wado-webserver/lib/routes/server/studies.mjs
@@ -31,6 +31,8 @@ export default function setRoutes(routerExpress, params, dir) {
       "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/frames/:frames",
       "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/lossy/:frames",
       "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/htj2k/:frames",
+      "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/htj2kThumbnail/:frames",
+      "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/jls/:frames",
       "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/jlsThumbnail/:frames",
     ],
     byteRangeRequest(params)

--- a/packages/static-wado-webserver/lib/routes/server/studies.mjs
+++ b/packages/static-wado-webserver/lib/routes/server/studies.mjs
@@ -4,6 +4,7 @@ import { defaultPostController as postController } from "../../controllers/serve
 import { defaultNotFoundController as notFoundController } from "../../controllers/server/notFoundControllers.mjs";
 import { defaultGetProxyController } from "../../controllers/server/proxyControllers.mjs";
 import { indexingStaticController, nonIndexingStaticController } from "../../controllers/server/staticControllers.mjs";
+import byteRangeRequest from "../../controllers/server/byteRangeRequest.mjs";
 
 /**
  * Set studies (/studies) routes.
@@ -22,9 +23,17 @@ export default function setRoutes(routerExpress, params, dir) {
     ["/studies/:studyUID/rendered", "/studies/:studyUID/series/:seriesUID/rendered", "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/rendered"],
     renderedMap
   );
+
+  // Gets the frame metadata - adds support for byte range requests and single part
   routerExpress.get(
-    ["/:ae/studies/:studyUID/series/:seriesUID/instances/:instanceUID/frames/:frames", "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/frames/:frames"],
-    multipartMap
+    [
+      "/:ae/studies/:studyUID/series/:seriesUID/instances/:instanceUID/frames/:frames",
+      "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/frames/:frames",
+      "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/lossy/:frames",
+      "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/htj2k/:frames",
+      "/studies/:studyUID/series/:seriesUID/instances/:instanceUID/jlsThumbnail/:frames",
+    ],
+    byteRangeRequest(params)
   );
   routerExpress.get("/studies/:studyUID/series/:seriesUID/instances/:instanceUID/frames", multipartIndexMap);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10804,15 +10804,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c= sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
 
-"typescript@>=3 < 6", typescript@>=5.0.2, typescript@^3.9.3, typescript@^5.0.2:
+"typescript@>=3 < 6", typescript@>=5.0.2, typescript@^3.9.3, typescript@^5.2.2:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
-
-typescript@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 uglify-js@^3.1.4:
   version "3.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,22 +1890,22 @@
   resolved "https://registry.yarnpkg.com/@cornerstonejs/codec-openjpeg/-/codec-openjpeg-1.2.2.tgz#f0b524235b5551426b46db197a37b06f8ac805d7"
   integrity sha512-b1O7lZacKXelgeV9n8XWZ7pTw3i4Bq4qQ26G5ahBjWoOw4QNcCrb5hPxWBxNB/I8AoNbJxAe+lyLtyQGfdrTbw==
 
-"@cornerstonejs/codec-openjph@>=2.4.2", "@cornerstonejs/codec-openjph@^2.4.2":
+"@cornerstonejs/codec-openjph@>=2.4.2", "@cornerstonejs/codec-openjph@>=2.4.3", "@cornerstonejs/codec-openjph@^2.4.3":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@cornerstonejs/codec-openjph/-/codec-openjph-2.4.2.tgz#e96721d56f6ec96f7f95c16321d88cc8467d8d81"
   integrity sha512-lgdvBvvNezleY+4pIe2ceUsJzlZe/0PipdeubQ3vZZOz3xxtHHMR1XFCl4fgd8gosR8COHuD7h6q+MwgrwBsng==
 
-"@cornerstonejs/dicom-codec@>=0.1.6", "@cornerstonejs/dicom-codec@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.npmjs.org/@cornerstonejs/dicom-codec/-/dicom-codec-0.1.9.tgz"
-  integrity sha512-RW/hZBAsxRn/ki+ImZw5LYWMQs/LjYQJ+bT2OMq+xfqYkSda3Rz/Hof1Xw1KB6luU2PtfLBaDey8wV2hy26gdA==
+"@cornerstonejs/dicom-codec@>=0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@cornerstonejs/dicom-codec/-/dicom-codec-0.1.10.tgz#1aaec2c7b98def95d52a02ebecb7572792c11f11"
+  integrity sha512-JKe3nBXTobLpCXmBOe1cwY0B83m4vVycL8NS5nfRoE2jKlPXFqyE65XCd1/VskVCE8Z7nTKjo5orgu1sJUnemQ==
   dependencies:
     "@cornerstonejs/codec-big-endian" "^0.1.0"
     "@cornerstonejs/codec-charls" "^1.2.3"
     "@cornerstonejs/codec-libjpeg-turbo-8bit" "^1.2.2"
     "@cornerstonejs/codec-little-endian" "^0.0.6"
     "@cornerstonejs/codec-openjpeg" "^1.2.2"
-    "@cornerstonejs/codec-openjph" "^2.4.2"
+    "@cornerstonejs/codec-openjph" "^2.4.3"
     browser-or-node "^2.0.0"
     jpeg-lossless-decoder-js "^2.0.4"
 


### PR DESCRIPTION
This change adds the ability to output to lossy encoded alternate frames directories for testing multiple transfer syntaxes, as well as byte range support on those outputted items.