### PR TITLE
MHT file upload - had wrong name

### DIFF
--- a/packages/s3-deploy/lib/S3Ops.mjs
+++ b/packages/s3-deploy/lib/S3Ops.mjs
@@ -64,6 +64,9 @@ class S3Ops {
     if (fileName[0] == "/") {
       fileName = fileName.substring(1);
     }
+    if (fileName.endsWith(".mht")) {
+      fileName = fileName.substring(0, fileName.length - 4);
+    }
     const extensionPos = fileName.lastIndexOf(".jhc");
     if (extensionPos > 0) {
       fileName = fileName.substring(0, extensionPos);


### PR DESCRIPTION
On file upload, we were getting names ending in .mht which weren't found.