### PR TITLE
fix: Overlay binary SS encoded objects were done as inline binary

### DIFF
--- a/packages/static-wado-webserver/lib/routes/client/viewer.mjs
+++ b/packages/static-wado-webserver/lib/routes/client/viewer.mjs
@@ -2,7 +2,7 @@ import { htmlMap } from "../../adapters/requestAdapters.mjs";
 import { defaultGetStaticController as staticController } from "../../controllers/client/staticControllers.mjs";
 
 export default function setViewerRoutes(routerExpress, params, dir) {
-  // routerExpress.get(["/viewer", "/viewer/*", "/findings", "/healthlake", "/microscopy", "/datasources", "/volume"], htmlMap);
-  routerExpress.get(/\/[a-zA-Z0-9_]+$/, htmlMap);
+  routerExpress.get(["/viewer", "/viewer/*", "/findings", "/healthlake", "/microscopy", "/datasources", "/volume"], htmlMap);
+  // routerExpress.get(/\/[a-zA-Z0-9_]+$/, htmlMap);
   routerExpress.use(staticController(dir));
 }


### PR DESCRIPTION
The overlay origin tag was being miscoded as inline binary.  Fixed encoding for SS inline.