### PR TITLE
Add batch size configuration

### DIFF
--- a/packages/static-wado-deploy/lib/DeployGroup.mjs
+++ b/packages/static-wado-deploy/lib/DeployGroup.mjs
@@ -22,7 +22,7 @@ class DeployGroup {
     this.deployPlugin = deployPlugin;
     this.groupName = groupName;
     this.options = {
-      concurrentUploads: 1000,  // Default number of concurrent uploads
+      concurrentUploads: 2,  // Default number of concurrent uploads
       ...options
     };
     this.group = configGroup(config, groupName);
@@ -239,8 +239,8 @@ class DeployGroup {
           return 0;
         }
         
-        console.log(`Found ${totalFiles} files to process`);
-        const batchSize = this.options.concurrentUploads || 1000;
+        const batchSize = this.options.concurrentUploads || 10;
+        console.noQuiet('Found', totalFiles, 'files to process in batches of', batchSize);
         let count = 0;
         
         // Stats object to track overall progress

--- a/packages/static-wado-deploy/lib/deployConfig.mjs
+++ b/packages/static-wado-deploy/lib/deployConfig.mjs
@@ -69,6 +69,11 @@ const { deployConfig } = ConfigPoint.register({
         description: "Set the delay between retries",
         defaultValue: 5000,
       },
+      {
+        key: "--concurrent-uploads <count>",
+        description: "Count of how many concurrent uploads are allowed",
+        defaultValue: 3,
+      },
     ],
 
     programs: [


### PR DESCRIPTION
Adds a --concurrent-uploads parameter to control upload concurrency.
Also, drop the upload limit way down from 1000 as that was causing unrecovered issues.