### PR TITLE
fix: Honour write back pressure so large multi-frame instances don't exhaust file handles

### DIFF
--- a/packages/create-dicomweb/README.md
+++ b/packages/create-dicomweb/README.md
@@ -28,6 +28,11 @@ createdicomweb create <DICOM-FILES-DIR ...>
 
 Note there is no glob support on the input parameter, so either directories or files need to be fully specified.
 
+Very large multi-frame instances (whole slide imaging, for example) write one file per frame. At most
+32 of those files are written at a time, and the reader waits for room before producing more frames.
+Use `--max-open-files <N>` to raise that for faster storage, or lower it if the system still runs
+short of file handles.
+
 ## Converting Static DICOMweb to Part 10
 
 Static DICOMweb files can be converted back into Part 10, provided:

--- a/packages/create-dicomweb/bin/createdicomweb.mjs
+++ b/packages/create-dicomweb/bin/createdicomweb.mjs
@@ -33,16 +33,38 @@ program
   .option('-v, --verbose', 'Enable verbose logging')
   .option('-q, --quiet', 'Disable noQuiet logging');
 
+/**
+ * Parses the --max-open-files option into a positive integer.
+ * @param {string|undefined} value - Raw option value
+ * @returns {number|undefined} - Parsed count, or undefined when not specified
+ */
+function parseMaxOpenFiles(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    console.error(`Invalid --max-open-files value: ${value}`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
 program
   .command('instance')
   .description('Store instance data')
   .argument('<part10>', 'part 10 file(s)')
   .option('--dicomdir <path>', 'Base directory path where binary .mht files will be written in DICOMweb structure','~/dicomweb')
+  .option('--max-open-files <N>', 'Maximum number of output files written at the same time (default: 32)')
   .action(async (fileName, options) => {
     updateVerboseLog();
     const instanceOptions = {};
     if (options.dicomdir) {
       instanceOptions.dicomdir = handleHomeRelative(options.dicomdir);
+    }
+    const maxOpenFiles = parseMaxOpenFiles(options.maxOpenFiles);
+    if (maxOpenFiles !== undefined) {
+      instanceOptions.maxOpenStreams = maxOpenFiles;
     }
     await instanceMain([fileName], instanceOptions);
   });
@@ -87,6 +109,7 @@ program
   .option('--no-study-index', 'Skip creating/updating studies/index.json.gz file')
   .option('--bulkdata-size <size>', 'Size threshold in bytes for public bulkdata tags (default: 131074, i.e. 128k + 2)')
   .option('--private-bulkdata-size <size>', 'Size threshold in bytes for private bulkdata tags (default: 128)')
+  .option('--max-open-files <N>', 'Maximum number of output files written at the same time (default: 32). Lower this if the system runs out of file handles on very large multi-frame instances')
   .action(async (fileNames, options) => {
     updateVerboseLog();
     const createOptions = {};
@@ -100,6 +123,10 @@ program
     }
     if (options.privateBulkdataSize) {
       createOptions.sizePrivateBulkdataTags = parseSizeToBytes(options.privateBulkdataSize);
+    }
+    const maxOpenFiles = parseMaxOpenFiles(options.maxOpenFiles);
+    if (maxOpenFiles !== undefined) {
+      createOptions.maxOpenStreams = maxOpenFiles;
     }
     await createMain(fileNames, createOptions);
   });

--- a/packages/create-dicomweb/lib/instance/DicomWebWriter.mjs
+++ b/packages/create-dicomweb/lib/instance/DicomWebWriter.mjs
@@ -4,6 +4,42 @@ import { uids } from '@radicalimaging/static-wado-util';
 import { MultipartStreamWriter } from './MultipartStreamWriter.mjs';
 import { StreamInfo, getStreamCounts } from './StreamInfo.mjs';
 
+/** Default maximum number of write streams (file handles) open at the same time */
+const DEFAULT_MAX_OPEN_STREAMS = 32;
+/**
+ * Lowest usable maxOpenStreams. The stream currently being written is itself open while the
+ * reader waits for room, so a limit below this could never be satisfied.
+ */
+const MIN_MAX_OPEN_STREAMS = 4;
+/** Default time to wait for open streams to close before continuing anyway */
+const DEFAULT_OPEN_STREAM_WAIT_MS = 30000;
+/** Default time to wait for in-flight closes at the end of an instance */
+const DEFAULT_DRAIN_TIMEOUT_MS = 60000;
+
+/**
+ * Creates a cancellable timeout promise. The timer must be cancelled once the caller is
+ * done with it, otherwise a pending timer keeps the process alive.
+ * @param {number} ms - Delay in milliseconds
+ * @returns {{ promise: Promise<void>, cancel: () => void }}
+ */
+function createTimeout(ms) {
+  let timeoutId;
+  const promise = new Promise(resolve => {
+    timeoutId = setTimeout(resolve, ms);
+  });
+  return { promise, cancel: () => clearTimeout(timeoutId) };
+}
+
+/**
+ * Yields to the event loop so stream 'finish'/'close' callbacks (which are macrotasks) get
+ * delivered. Awaiting only promises is not enough: a parse loop that never yields to the
+ * macrotask queue keeps opening files while none of them ever finish closing.
+ * @returns {Promise<void>}
+ */
+function yieldToEventLoop() {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
 const EQUIVALENT_UNCOMPRESSED_TRANSFER_SYNTAX_UIDS = new Set([
   '1.2.840.10008.1.2',   // Implicit VR Little Endian
   '1.2.840.10008.1.2.1', // Explicit VR Little Endian
@@ -30,6 +66,8 @@ export class DicomWebWriter {
    * @param {Object} options - Configuration options (required)
    * @param {string} options.baseDir - Base directory for output
    * @param {{ add: (p: Promise) => Promise }|undefined} [options.streamWritePromiseTracker] - Optional tracker for stream write promises (e.g. for back pressure)
+   * @param {number} [options.maxOpenStreams=32] - Maximum number of streams (file handles) open at once; see awaitOpenStreamLimit
+   * @param {number} [options.openStreamWaitMs=30000] - Max time awaitOpenStreamLimit waits for room before continuing anyway
    */
   constructor(informationProvider, options) {
     if (!informationProvider || typeof informationProvider !== 'object') {
@@ -44,8 +82,15 @@ export class DicomWebWriter {
     this.informationProvider = informationProvider;
     this.options = options;
     this.streamWritePromiseTracker = options.streamWritePromiseTracker ?? null;
+    this.maxOpenStreams = Math.max(
+      MIN_MAX_OPEN_STREAMS,
+      options.maxOpenStreams ?? DEFAULT_MAX_OPEN_STREAMS
+    );
+    this.openStreamWaitMs = options.openStreamWaitMs ?? DEFAULT_OPEN_STREAM_WAIT_MS;
     this.openStreams = new Map(); // key -> stream info
     this.streamErrors = new Map(); // key -> error
+    /** Counter used to keep streamKey unique when a key is re-used while still open */
+    this._streamKeySequence = 0;
 
     // Log tracker ID for debugging
     if (this.streamWritePromiseTracker) {
@@ -182,7 +227,17 @@ export class DicomWebWriter {
     data.stream = targetStream;
     data.filename = actualFilename;
 
-    const streamKey = options.streamKey || `${path.replace(/\\/g, '/')}:${data.filename}`;
+    let streamKey = options.streamKey || `${path.replace(/\\/g, '/')}:${data.filename}`;
+    if (this.openStreams.has(streamKey)) {
+      // Re-using the key of a stream that is still open would orphan that stream: its entry
+      // would be replaced, so nothing would ever close it and its file handle would leak.
+      // Duplicate keys happen when the same tag/content hash is written twice in one instance.
+      const uniqueKey = `${streamKey}#${(this._streamKeySequence += 1)}`;
+      console.verbose(
+        `[DicomWebWriter] streamKey ${streamKey} is still open, opening as ${uniqueKey}`
+      );
+      streamKey = uniqueKey;
+    }
     data.streamKey = streamKey;
 
     const streamInfo = new StreamInfo(this, data);
@@ -438,6 +493,104 @@ export class DicomWebWriter {
    */
   getOpenStreams() {
     return this.openStreams;
+  }
+
+  /**
+   * Back pressure: waits until fewer than maxOpenStreams streams are open.
+   *
+   * Frames and bulkdata are closed asynchronously (closeStream is not awaited by the filters),
+   * so a fast parser - a whole slide image with tens of thousands of frames, for example - can
+   * open files far faster than they close and run the process out of file handles. Callers apply
+   * this before producing more data (see the listener drain in instanceFromStream).
+   *
+   * Never throws and never waits forever: after timeoutMs it logs and lets the caller continue.
+   *
+   * @param {number} [maxOpenStreams] - Limit to wait for; defaults to this.maxOpenStreams
+   * @param {number} [timeoutMs] - Max time to wait; defaults to this.openStreamWaitMs
+   * @returns {Promise<number>} - Number of open streams at the time it resolved
+   */
+  async awaitOpenStreamLimit(
+    maxOpenStreams = this.maxOpenStreams,
+    timeoutMs = this.openStreamWaitMs
+  ) {
+    if (this.openStreams.size < maxOpenStreams) {
+      return this.openStreams.size;
+    }
+
+    const timeout = createTimeout(timeoutMs);
+    let timedOut = false;
+    timeout.promise.then(() => {
+      timedOut = true;
+    });
+
+    try {
+      while (this.openStreams.size >= maxOpenStreams && !timedOut) {
+        // The oldest stream is the one most likely to finish first, and never the one being
+        // written right now (maxOpenStreams is at least MIN_MAX_OPEN_STREAMS), so waiting on
+        // it cannot deadlock against the caller that is waiting for room.
+        const oldest = this.openStreams.values().next().value;
+        if (!oldest?.promise) break;
+        await Promise.race([oldest.promise.catch(() => undefined), timeout.promise]);
+        await yieldToEventLoop();
+      }
+    } finally {
+      timeout.cancel();
+    }
+
+    const openCount = this.openStreams.size;
+    if (openCount >= maxOpenStreams) {
+      console.noQuiet(
+        `[DicomWebWriter] back pressure timed out after ${timeoutMs}ms with ${openCount} open streams; continuing`
+      );
+    }
+    return openCount;
+  }
+
+  /**
+   * Waits for every open stream to finish, then destroys any that never completed.
+   * Call this once an instance is fully parsed: the filters close frame and bulkdata streams
+   * without awaiting, so some closes are still in flight, and anything that was never closed
+   * would otherwise hold its file handle until the process exits.
+   *
+   * @param {number} [timeoutMs=60000] - Max time to wait for in-flight closes
+   * @returns {Promise<void>}
+   */
+  async drainOpenStreams(timeoutMs = DEFAULT_DRAIN_TIMEOUT_MS) {
+    if (this.openStreams.size === 0) {
+      return;
+    }
+
+    const timeout = createTimeout(timeoutMs);
+    try {
+      await Promise.race([this.awaitAllStreams(), timeout.promise]);
+    } finally {
+      timeout.cancel();
+    }
+
+    // closeStream removes its entry after the stream's promise settles, so give those
+    // continuations a chance to run before deciding a stream was left behind.
+    for (let i = 0; i < 10 && this.openStreams.size > 0; i++) {
+      await yieldToEventLoop();
+    }
+
+    // Streams that ended are mid-close: their handle is already released. Anything else
+    // never finished, so destroy it to release the handle.
+    const lingering = Array.from(this.openStreams.entries()).filter(
+      ([, streamInfo]) => !streamInfo._ended
+    );
+    if (lingering.length === 0) {
+      return;
+    }
+
+    console.warn(
+      `[DicomWebWriter] ${lingering.length} stream(s) were never closed; destroying them to release file handles: ${lingering
+        .map(([streamKey]) => streamKey)
+        .join(', ')}`
+    );
+    const error = new Error('Stream was not closed before writing completed');
+    for (const [streamKey] of lingering) {
+      this.recordStreamError(streamKey, error, true);
+    }
   }
 
   /**

--- a/packages/create-dicomweb/lib/instance/StreamInfo.mjs
+++ b/packages/create-dicomweb/lib/instance/StreamInfo.mjs
@@ -16,6 +16,33 @@ const STREAM_OPEN_WARN_THRESHOLD = 500;
 const STREAM_OPEN_WARN_STEP = 100;
 /** Next count at which to log (500, 600, 700, …); reset when count drops below threshold */
 let _streamOpenNextLogAt = STREAM_OPEN_WARN_THRESHOLD;
+/** Max time to wait for a 'drain' event before writing more data */
+const DRAIN_WAIT_MS = 250;
+
+/**
+ * Waits until a stream drains, resolving early if it errors/closes, and after timeoutMs at the latest.
+ * Every listener added is removed again, so instances with thousands of frames don't accumulate
+ * 'drain' listeners on their streams (which leaks memory and triggers MaxListenersExceededWarning).
+ * @param {import('stream').Writable} stream - The stream that returned false from write()
+ * @param {number} timeoutMs - Max time to wait for the drain event
+ * @returns {Promise<void>}
+ */
+function waitForDrain(stream, timeoutMs) {
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      stream.removeListener('drain', finish);
+      stream.removeListener('close', finish);
+      resolve();
+    };
+    const timeoutId = setTimeout(finish, timeoutMs);
+    stream.once('drain', finish);
+    stream.once('close', finish);
+  });
+}
 
 /**
  * Normalizes a value to an array of Buffers. Supports ArrayBuffer, Buffer, TypedArray, or Array of same.
@@ -86,6 +113,30 @@ export class StreamInfo {
       this._reject = reject;
     });
     this.promise = completionPromise;
+
+    this._attachErrorHandlers();
+  }
+
+  /**
+   * Listens for errors on all of this stream's layers so a failure (disk full, EPIPE, …)
+   * records the failure and destroys the streams. Without this, an error emitted before
+   * end() attaches its handlers either crashes the process as an unhandled 'error' event
+   * or leaves the file handle open forever, since 'finish' never arrives after an error.
+   * @private
+   */
+  _attachErrorHandlers() {
+    const onError = error => {
+      if (this._ended || this.failed) return;
+      console.verbose(
+        `[StreamInfo] error on stream ${this.streamKey ?? 'unknown'}: ${error?.message ?? error}`
+      );
+      this.recordFailure(error);
+    };
+    for (const stream of [this.stream, this.gzipStream, this.fileStream]) {
+      if (stream && typeof stream.once === 'function') {
+        stream.once('error', onError);
+      }
+    }
   }
 
   /**
@@ -194,15 +245,10 @@ export class StreamInfo {
       const item = this._queue.shift();
       if (item.buffers) {
         for (const buf of item.buffers) {
+          if (this.failed || stream.destroyed) break;
           const ok = stream.write(buf);
           if (!ok) {
-            await new Promise(resolve => {
-              const timeout = setTimeout(() => resolve(), 250);
-              stream.once('drain', () => {
-                clearTimeout(timeout);
-                resolve();
-              });
-            });
+            await waitForDrain(stream, DRAIN_WAIT_MS);
           }
         }
       } else if (item.run !== undefined) {

--- a/packages/create-dicomweb/lib/instance/instanceFromStream.mjs
+++ b/packages/create-dicomweb/lib/instance/instanceFromStream.mjs
@@ -94,9 +94,11 @@ function createProgressFilter(parentJob, parseJob, throttleMs) {
  * @param {string} options.dicomdir - Base directory for writing files (required if DicomWebWriter is not provided)
  * @param {Function} options.DicomWebWriter - Constructor for DicomWebWriter. Defaults to FileDicomWebWriter if dicomdir is provided
  * @param {Object} options.writerOptions - Additional options to pass to the DicomWebWriter constructor
- * @param {{ add: (p: Promise) => Promise, limitUnsettled: (max, timeoutMs) => Promise }|undefined} [options.streamWritePromiseTracker] - Optional tracker for stream write promises (e.g. for back pressure). When provided (or via options.writerOptions.streamWritePromiseTracker), the listener drain is set so the reader awaits limitUnsettled before emitting more frame data, preventing too many open streams.
- * @param {number} [options.drainMaxUnsettled=25] - Max unsettled stream writes allowed before reader waits (used when streamWritePromiseTracker is set).
- * @param {number} [options.drainTimeoutMs=5000] - Timeout in ms for drain wait (used when streamWritePromiseTracker is set).
+ * @param {{ add: (p: Promise) => Promise, limitUnsettled: (max, timeoutMs) => Promise }|undefined} [options.streamWritePromiseTracker] - Optional tracker for stream write promises (e.g. for back pressure). One is created when omitted. It is always passed to the writer, which registers every stream's completion promise with it, and the listener drain awaits limitUnsettled before emitting more frame data so we never open more streams than can be consumed.
+ * @param {number} [options.drainMaxUnsettled=25] - Max unsettled stream writes allowed before reader waits.
+ * @param {number} [options.drainTimeoutMs=5000] - Timeout in ms for drain wait.
+ * @param {number} [options.maxOpenStreams=32] - Max streams (file handles) the writer keeps open at once; the reader waits for room before emitting more frame/bulkdata values.
+ * @param {number} [options.drainOpenStreamsTimeoutMs=60000] - Max time to wait for in-flight closes once the instance is parsed.
  * @param {boolean} options.bulkdata - Enable bulkdata filter (default: true if writer exists). Set to false to use frames filter instead
  * @param {number} options.sizeBulkdataTags - Size threshold in bytes for public tags (default: 128k + 2 bytes)
  * @param {number} options.sizePrivateBulkdataTags - Size threshold in bytes for private tags (default: 128 bytes)
@@ -176,10 +178,23 @@ export async function instanceFromStream(stream, options = {}) {
   const DicomWebWriterClass =
     options.DicomWebWriter || (options.dicomdir ? FileDicomWebWriter : null);
 
+  // The tracker has to exist before the writer, because the writer is what registers each
+  // stream's completion promise with it. Back pressure below waits on those promises, so a
+  // tracker the writer does not know about would always look idle and never push back.
+  const streamWritePromiseTracker =
+    options.streamWritePromiseTracker ||
+    options.writerOptions?.streamWritePromiseTracker ||
+    createPromiseTracker('instanceFromStream');
+
   // Create writer using the listener's information object
   let writer = null;
   if (DicomWebWriterClass) {
-    const writerOptions = { baseDir: options.dicomdir, ...options.writerOptions };
+    const writerOptions = {
+      baseDir: options.dicomdir,
+      maxOpenStreams: options.maxOpenStreams,
+      ...options.writerOptions,
+      streamWritePromiseTracker,
+    };
     writer = new DicomWebWriterClass(information, writerOptions);
   }
 
@@ -222,16 +237,17 @@ export async function instanceFromStream(stream, options = {}) {
   // The listener will automatically create its own information filter and call init()
   const listener = new DicomMetadataListener({ information }, ...filters);
 
-  // Wire drain (backpressure) to the stream write promise tracker so we don't emit
-  // frame fragments faster than streams can be consumed (prevents too many open streams).
-  const streamWritePromiseTracker =
-    options.streamWritePromiseTracker || createPromiseTracker('instanceFromStream');
+  // Wire drain (backpressure) to the writer and the stream write promise tracker so we don't
+  // emit frame fragments faster than streams can be consumed (prevents too many open files).
   if (writer) {
     const drainMaxUnsettled = options.drainMaxUnsettled ?? 25;
     const drainTimeoutMs = options.drainTimeoutMs ?? 5000;
-    listener.setDrain(() =>
-      streamWritePromiseTracker.limitUnsettled(drainMaxUnsettled, drainTimeoutMs)
-    );
+    listener.setDrain(async () => {
+      // Open file handles first: they are the hard resource limit, and the writer knows
+      // exactly how many of its own streams are still open.
+      await writer.awaitOpenStreamLimit();
+      return streamWritePromiseTracker.limitUnsettled(drainMaxUnsettled, drainTimeoutMs);
+    });
   }
 
   // Final validation of stream state before reading (especially for ReadBufferStream)
@@ -325,8 +341,10 @@ export async function instanceFromStream(stream, options = {}) {
       await writer.closeStream(metadataStream.streamKey);
     }
 
-    // Wait for all frame writes to complete before returning
-    await writer?.awaitAllStreams();
+    // Wait for all frame/bulkdata writes to complete before returning. The filters close those
+    // streams without awaiting, so this both flushes the in-flight closes and releases the
+    // handle of anything that was never closed.
+    await writer?.drainOpenStreams(options.drainOpenStreamsTimeoutMs);
     console.verbose('Finished writing metadata to file', information.sopInstanceUid);
 
     const result = { fmi, dict, writer, information: listener.information };

--- a/packages/create-dicomweb/lib/instance/writeBulkdataFilter.mjs
+++ b/packages/create-dicomweb/lib/instance/writeBulkdataFilter.mjs
@@ -247,7 +247,7 @@ export function writeBulkdataFilter(options = {}) {
       return next(result);
     }
 
-    const streamKey = `bulkdata:${currentTag}@${level}:${hashPath}`;
+    let streamKey = `bulkdata:${currentTag}@${level}:${hashPath}`;
 
     try {
       const relativePath = `studies/${studyUID}/bulkdata/${hashPath.substring(0, hashPath.lastIndexOf('/'))}`;
@@ -263,6 +263,9 @@ export function writeBulkdataFilter(options = {}) {
         gzip: true,
         streamKey,
       });
+      // The writer de-duplicates keys that are still open, so close the key it assigned;
+      // closing the requested key could otherwise close (or miss) the wrong stream.
+      streamKey = streamInfo.streamKey;
 
       for (const v of valueArray) {
         const buf = v instanceof ArrayBuffer ? Buffer.from(v) : v;
@@ -270,7 +273,11 @@ export function writeBulkdataFilter(options = {}) {
         streamInfo.write(buf);
       }
 
-      bulkdataWriter.closeStream(streamKey);
+      // Not awaited: the parser is synchronous here, back pressure comes from the listener drain.
+      bulkdataWriter.closeStream(streamKey).catch(error => {
+        console.error(`Error closing bulkdata stream ${streamKey}:`, error);
+        bulkdataWriter.recordStreamError(streamKey, error, true);
+      });
     } catch (error) {
       console.error(`Error writing bulkdata for tag ${currentTag}:`, error);
       bulkdataWriter.recordStreamError(streamKey, error, true);

--- a/packages/create-dicomweb/lib/instance/writeMultipartFramesFilter.mjs
+++ b/packages/create-dicomweb/lib/instance/writeMultipartFramesFilter.mjs
@@ -21,10 +21,17 @@ const TAGS = {
  * @returns {string} - Relative path to the written frame file (e.g. 'frames/1.mht')
  */
 function writeFullFrame(frameWriter, frameNumber, v) {
-  const streamKey = `frame:${frameNumber}`;
-  const streamInfo = frameWriter.openFrameStream(frameNumber, { streamKey });
+  const streamInfo = frameWriter.openFrameStream(frameNumber, {
+    streamKey: `frame:${frameNumber}`,
+  });
   streamInfo.write(v);
-  frameWriter.closeStream(streamKey);
+  // Closing is not awaited here (the parser is synchronous at this point); back pressure comes
+  // from the listener drain. Use the key the writer assigned, which may be de-duplicated.
+  const streamKey = streamInfo.streamKey;
+  frameWriter.closeStream(streamKey).catch(err => {
+    console.error(`Error closing frame stream ${streamKey}:`, err);
+    frameWriter.recordStreamError(streamKey, err, true);
+  });
   return `frames/${frameNumber}.mht`;
 }
 
@@ -130,8 +137,9 @@ export function writeMultipartFramesFilter(options = {}) {
       }
       currentFrameNumber++;
       const frameNumber = currentFrameNumber;
-      const streamKey = `frame:${frameNumber}`;
-      pixelDataStreamInfo = frameWriter.openFrameStream(frameNumber, { streamKey });
+      pixelDataStreamInfo = frameWriter.openFrameStream(frameNumber, {
+        streamKey: `frame:${frameNumber}`,
+      });
     }
 
     return next(dest);

--- a/packages/create-dicomweb/test/openStreamBackPressure.jest.mjs
+++ b/packages/create-dicomweb/test/openStreamBackPressure.jest.mjs
@@ -1,0 +1,274 @@
+import fs from 'fs';
+import path from 'path';
+import { Writable } from 'stream';
+import { FileDicomWebWriter } from '../lib/instance/FileDicomWebWriter.mjs';
+import { StreamInfo } from '../lib/instance/StreamInfo.mjs';
+import { instanceFromStream } from '../lib/instance/instanceFromStream.mjs';
+
+const packageRoot = process.cwd().endsWith('create-dicomweb')
+  ? process.cwd()
+  : path.resolve(process.cwd(), 'packages/create-dicomweb');
+
+/** Resolves on the next event loop turn, so stream finish/close callbacks are delivered */
+const tick = () => new Promise(resolve => setImmediate(resolve));
+
+describe('open stream back pressure', () => {
+  let informationProvider;
+  let writer;
+  let tempDir;
+
+  beforeEach(() => {
+    informationProvider = {
+      studyInstanceUid: '1.2.3.4.5',
+      seriesInstanceUid: '1.2.3.4.6',
+      sopInstanceUid: '1.2.3.4.7',
+      transferSyntaxUid: '1.2.840.10008.1.2.4.50', // JPEG baseline, so frames are not gzipped
+    };
+    tempDir = path.join(packageRoot, 'tmp/back-pressure-test');
+    writer = new FileDicomWebWriter(informationProvider, {
+      baseDir: tempDir,
+      maxOpenStreams: 4,
+    });
+  });
+
+  afterEach(async () => {
+    for (const streamKey of Array.from(writer.getOpenStreams().keys())) {
+      await writer.closeStream(streamKey).catch(() => {});
+    }
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('awaitOpenStreamLimit waits until a stream closes, then resolves', async () => {
+    for (let frameNumber = 1; frameNumber <= 4; frameNumber++) {
+      writer.openFrameStream(frameNumber).write(Buffer.from(`frame ${frameNumber}`));
+    }
+    expect(writer.getOpenStreams().size).toBe(4);
+
+    let resolved = false;
+    const waiting = writer.awaitOpenStreamLimit(4, 5000).then(count => {
+      resolved = true;
+      return count;
+    });
+
+    // At the limit, so the reader must wait rather than open a fifth file
+    await tick();
+    await tick();
+    expect(resolved).toBe(false);
+
+    await writer.closeStream('frame:1');
+    const openCount = await waiting;
+    expect(resolved).toBe(true);
+    expect(openCount).toBeLessThan(4);
+  });
+
+  test('awaitOpenStreamLimit returns immediately when below the limit', async () => {
+    writer.openFrameStream(1).write(Buffer.from('frame 1'));
+    await expect(writer.awaitOpenStreamLimit(4, 5000)).resolves.toBe(1);
+  });
+
+  test('awaitOpenStreamLimit gives up after the timeout instead of hanging', async () => {
+    for (let frameNumber = 1; frameNumber <= 4; frameNumber++) {
+      writer.openFrameStream(frameNumber).write(Buffer.from(`frame ${frameNumber}`));
+    }
+    // Nothing is ever closed, so this can only resolve via the timeout
+    await expect(writer.awaitOpenStreamLimit(4, 50)).resolves.toBe(4);
+    expect(writer.getOpenStreams().size).toBe(4);
+  });
+
+  test('re-using a streamKey that is still open does not orphan the first stream', async () => {
+    const first = writer.openStream('bulkdata', 'duplicate.bin', { streamKey: 'bulkdata:dup' });
+    const second = writer.openStream('bulkdata', 'duplicate.bin', { streamKey: 'bulkdata:dup' });
+
+    expect(first.streamKey).toBe('bulkdata:dup');
+    expect(second.streamKey).not.toBe('bulkdata:dup');
+    expect(writer.getOpenStreams().size).toBe(2);
+    expect(writer.getOpenStreams().get(first.streamKey)).toBe(first);
+    expect(writer.getOpenStreams().get(second.streamKey)).toBe(second);
+
+    first.write(Buffer.from('first'));
+    second.write(Buffer.from('second'));
+
+    await writer.closeStream(first.streamKey);
+    await writer.closeStream(second.streamKey);
+    expect(writer.getOpenStreams().size).toBe(0);
+  });
+
+  test('drainOpenStreams flushes in-flight closes', async () => {
+    for (let frameNumber = 1; frameNumber <= 3; frameNumber++) {
+      writer.openFrameStream(frameNumber).write(Buffer.from(`frame ${frameNumber}`));
+      // Close without awaiting, exactly like the frame/bulkdata filters do
+      writer.closeStream(`frame:${frameNumber}`);
+    }
+
+    await writer.drainOpenStreams(5000);
+
+    expect(writer.getOpenStreams().size).toBe(0);
+    const framesDir = path.join(
+      tempDir,
+      'studies',
+      '1.2.3.4.5',
+      'series',
+      '1.2.3.4.6',
+      'instances',
+      '1.2.3.4.7',
+      'frames'
+    );
+    expect(fs.readdirSync(framesDir).sort()).toEqual(['1.mht', '2.mht', '3.mht']);
+  });
+
+  test('drainOpenStreams destroys streams that were never closed', async () => {
+    const streamInfo = writer.openFrameStream(1);
+    streamInfo.write(Buffer.from('frame 1'));
+    streamInfo.promise.catch(() => {});
+
+    await writer.drainOpenStreams(50);
+
+    expect(writer.getOpenStreams().size).toBe(0);
+    expect(streamInfo.stream.destroyed).toBe(true);
+    expect(writer.hasStreamErrors()).toBe(true);
+  });
+});
+
+describe('StreamInfo back pressure', () => {
+  test('repeated back pressure does not accumulate drain listeners', async () => {
+    // Holds back the write callbacks, so every write() reports back pressure and each queued
+    // chunk has to wait out the drain timeout
+    let releaseWrites = false;
+    const pending = [];
+    const ws = new Writable({
+      highWaterMark: 1,
+      write(chunk, enc, cb) {
+        if (releaseWrites) {
+          cb();
+          return;
+        }
+        pending.push(cb);
+      },
+    });
+
+    const mockWriter = { _recordStreamFailure() {} };
+    const streamInfo = new StreamInfo(mockWriter, {
+      stream: ws,
+      fileStream: ws,
+      streamKey: 'test',
+      filename: 'x',
+      relativePath: '.',
+    });
+
+    for (let i = 0; i < 4; i++) {
+      streamInfo.write(Buffer.from(`chunk ${i}`));
+    }
+
+    // Let the queue hit back pressure and time out its drain waits a couple of times
+    await new Promise(resolve => setTimeout(resolve, 700));
+    expect(ws.listenerCount('drain')).toBeLessThanOrEqual(1);
+    expect(ws.listenerCount('close')).toBeLessThanOrEqual(1);
+
+    releaseWrites = true;
+    pending.forEach(cb => cb());
+    await streamInfo.end();
+  });
+
+  test('a stream error is recorded rather than left open or thrown', async () => {
+    const ws = new Writable({
+      write(chunk, enc, cb) {
+        cb(new Error('disk full'));
+      },
+    });
+
+    const failures = [];
+    const mockWriter = {
+      _recordStreamFailure(streamKey, info, error) {
+        failures.push(error.message);
+      },
+    };
+    const streamInfo = new StreamInfo(mockWriter, {
+      stream: ws,
+      fileStream: ws,
+      streamKey: 'test',
+      filename: 'x',
+      relativePath: '.',
+    });
+    streamInfo.promise.catch(() => {});
+
+    streamInfo.write(Buffer.from('data'));
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(failures).toEqual(['disk full']);
+    expect(streamInfo.failed).toBe(true);
+    // end() must still complete (an errored stream never emits 'finish')
+    await expect(streamInfo.end()).resolves.toBeUndefined();
+  });
+});
+
+describe('instanceFromStream back pressure wiring', () => {
+  const dicomFilePath = path.resolve(
+    packageRoot,
+    '../../packages/static-wado-creator/dicom/jpeg8bit.dcm'
+  );
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = path.join(packageRoot, 'tmp/back-pressure-instance');
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('the writer shares the tracker the drain waits on, and no stream is left open', async () => {
+    const writerOptionsSeen = [];
+    class RecordingWriter extends FileDicomWebWriter {
+      constructor(informationProvider, options) {
+        super(informationProvider, options);
+        writerOptionsSeen.push(options);
+      }
+    }
+
+    const result = await instanceFromStream(fs.createReadStream(dicomFilePath), {
+      dicomdir: tempDir,
+      DicomWebWriter: RecordingWriter,
+      maxOpenStreams: 4,
+      drainMaxUnsettled: 2,
+    });
+
+    expect(writerOptionsSeen).toHaveLength(1);
+    const tracker = writerOptionsSeen[0].streamWritePromiseTracker;
+    expect(tracker).toBeDefined();
+    expect(writerOptionsSeen[0].maxOpenStreams).toBe(4);
+    expect(result.writer.streamWritePromiseTracker).toBe(tracker);
+    expect(result.writer.maxOpenStreams).toBe(4);
+
+    // Every stream the writer opened was registered with the tracker used for back pressure,
+    // and all of them settled - that is what makes the drain able to push back.
+    expect(tracker.getSettledCount()).toBeGreaterThan(0);
+    expect(tracker.getUnsettledCount()).toBe(0);
+    expect(result.writer.getOpenStreams().size).toBe(0);
+  });
+
+  test('a caller supplied tracker is used for the writer as well', async () => {
+    const added = [];
+    const tracker = {
+      add(promise) {
+        added.push(promise);
+        return promise;
+      },
+      limitUnsettled: () => Promise.resolve(0),
+      getUnsettledCount: () => 0,
+      getSettledCount: () => added.length,
+      getTrackerId: () => 'test-tracker',
+    };
+
+    const result = await instanceFromStream(fs.createReadStream(dicomFilePath), {
+      dicomdir: tempDir,
+      streamWritePromiseTracker: tracker,
+    });
+
+    expect(result.writer.streamWritePromiseTracker).toBe(tracker);
+    expect(added.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Writing a whole slide image opened one file per frame with no effective limit: "[StreamInfo] open file count exceeded 500 by 0: totalOpen=500 totalClosed=107", climbing from there until the process ran out of handles.

The drain hook was already wired to a promise tracker, but instanceFromStream created that tracker *after* the writer and never passed it to the writer. The writer is what registers each stream's completion promise, so the tracker the drain waited on was always empty and limitUnsettled returned immediately. Create the tracker first and pass it to the writer, so back pressure actually engages.

Also bound and release handles directly:

- DicomWebWriter.awaitOpenStreamLimit waits until fewer than maxOpenStreams (default 32, --max-open-files) streams are open, yielding to the event loop so stream finish callbacks are delivered instead of only draining microtasks. The listener drain awaits it before emitting more frame/bulkdata values.
- DicomWebWriter.drainOpenStreams flushes the in-flight closes at the end of an instance (the filters close frames without awaiting) and destroys anything that was never closed rather than leaking its handle.
- openStream no longer replaces an open stream when a streamKey repeats; the replaced stream was orphaned, so it never closed and its tracked promise never settled. The filters close the key the writer assigned.
- StreamInfo removes its 'drain' listeners when the wait times out; they used to accumulate one per timed-out write.
- StreamInfo records stream errors as failures, so an error before end() attaches its handlers no longer crashes the process or leaves the handle open forever.

Verified on 22MB, 99MB and 1.3GB WSI instances (1292, 1586 and 24617 frames): no open file count warnings, no temp files left behind, and for the 22MB instance output byte-identical to before apart from the random multipart boundaries, with unchanged runtime.